### PR TITLE
Fix typo in URL

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -98,7 +98,7 @@
   <footer>
     <br>
       <div class="text-center">
-        Voor algemene informatie over de verkiezingen kunt u terecht op <a href="https://elkestemtelt.nl/" target="_blank" rel="noopener">elkestemt.nl</a> van de Rijksoverheid
+        Voor algemene informatie over de verkiezingen kunt u terecht op <a href="https://elkestemtelt.nl/" target="_blank" rel="noopener">elkestemtelt.nl</a> van de Rijksoverheid
       </div>
     <br>
     <div class="container">

--- a/app/templates/over-deze-website.html
+++ b/app/templates/over-deze-website.html
@@ -11,7 +11,7 @@
 
   <p>Het platform ‘Waar is mijn stemlokaal?’ helpt kiezers om hun een stembureau of afgiftepunt te vinden. Stembureaus en afgiftepunten kunnen op deze website via een kaart gezocht worden of via het downloaden van de open databestanden. Deze open databestanden kunnen door iedereen vrijelijk hergebruikt worden voor andere toepassingen.</p>
 
-  <p>Voor algemene informatie over de verkiezingen kunt u terecht op <a href="https://elkestemtelt.nl/" target="_blank" rel="noopener">elkestemt.nl</a> van de Rijksoverheid. Ook bij de <a href="https://www.kiesraad.nl/" target="_blank" rel="noopener">Kiesraad</a> kunt u meer informatie over verkiezingen vinden.</p>
+  <p>Voor algemene informatie over de verkiezingen kunt u terecht op <a href="https://elkestemtelt.nl/" target="_blank" rel="noopener">elkestemtelt.nl</a> van de Rijksoverheid. Ook bij de <a href="https://www.kiesraad.nl/" target="_blank" rel="noopener">Kiesraad</a> kunt u meer informatie over verkiezingen vinden.</p>
 
   <h2>Waar komt de data vandaan?</h2>
   <p>VNG Realisatie heeft vanuit de praktijkbeproeving Open Data Standaarden <a href="https://www.da2020.nl/ondersteuningsmiddelen/platform-waar-mijn-stemlokaal" target="_blank" rel="noopener">specificaties opgesteld voor stembureaus en afgiftepunten</a>. Hiermee kunnen 355 (bijzondere) gemeenten op een uniforme wijze informatie over hun stembureaus en afgiftepunten aanleveren. Dit platform maakt gebruik van de door VNG opgestelde Stembureaus Open Data Standaard voor het ontsluiten van de lijsten met stembureaus en afgiftepunten:


### PR DESCRIPTION
Noticed a typo in the URL linking to elkestemtelt.nl, which was shown as elkestemt.nl.