### PR TITLE
Improved search 'gemeente', added simplified gemeentenamen, simplified html of gemeente search result list

### DIFF
--- a/app/assets/scripts/routes/map.js
+++ b/app/assets/scripts/routes/map.js
@@ -90,37 +90,21 @@ export default {
 
     // List gemeenten on the homepage
     StembureausApp.show_gemeenten = function (matches, query) {
-      $('#results-search-gemeenten').empty();
-      for (var i=0; i < matches.length; i++) {
-
-        // Deal with alternative municipality names
-        var gemeente_uri = matches[i]['item']['gemeente_naam']
-        if (matches[i]['item']['gemeente_naam'] == 'Den Haag') {
-          gemeente_uri = "'s-Gravenhage"
-        }
-        else if (matches[i]['item']['gemeente_naam'] == 'Den Bosch') {
-          gemeente_uri = "'s-Hertogenbosch"
-        }
-        else if (matches[i]['item']['gemeente_naam'] == 'De Friese Meren') {
-          gemeente_uri = "De Fryske Marren"
-        }
-        else if (matches[i]['item']['gemeente_naam'] == 'Noordoost-Friesland') {
-          gemeente_uri = "Noardeast-Fryslân"
-        }
-        else if (matches[i]['item']['gemeente_naam'] == 'Zuidwest-Friesland') {
-          gemeente_uri = "Súdwest-Fryslân"
-        }
-
-        var target = StembureausApp.links_external ? ' target="_blank" rel="noopener"' : '';
-        $('#results-search-gemeenten').append($(
-          '<ul>' +
-          '<li><h3><a href="/s/' + gemeente_uri + '"' + target + ">" + matches[i]['item']['gemeente_naam'] + '</a><h3></li>' +
-          '</ul>'
-        ))
-      }
-
+      const results_search_gemeenten = $('#results-search-gemeenten');
+      results_search_gemeenten.empty();
       if (matches.length == 0 && query.length > 1) {
-        $('#results-search-gemeenten').append($('<p>Helaas, we hebben geen gemeente gevonden voor uw zoekopdracht. Wellicht staat uw gemeente onder een andere naam bekend?</p>'));
+        results_search_gemeenten.append($('<p>Helaas, we hebben geen gemeente gevonden voor uw zoekopdracht. Wellicht staat uw gemeente onder een andere naam bekend?</p>'));
+      } else {
+        const unique_matches =
+          Array.from(
+            new Set(matches.map(match => match.item.gemeente_uri || match.item.gemeente_naam)))
+            .sort();
+        let lijst = '';
+        unique_matches.forEach(gemeente => {
+          const target = StembureausApp.links_external ? ' target="_blank" rel="noopener"' : '';
+          lijst += '<li><h3><a href="/s/' + gemeente + '"' + target + ">" + gemeente + '</a></h3></li>';
+        });
+        results_search_gemeenten.append($('<ul>' + lijst + '</ul>'));
       }
     };
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -137,11 +137,13 @@ with open('app/data/kieskringen.csv') as IN:
 # A list containing all gemeentenamen, used in the search box on the
 # homepage. Also allow for some alternative municipality names.
 alternative_names = [
-    {'gemeente_naam': 'Den Haag'},
-    {'gemeente_naam': 'Den Bosch'},
-    {'gemeente_naam': 'De Friese Meren'},
-    {'gemeente_naam': 'Noordoost-Friesland'},
-    {'gemeente_naam': 'Zuidwest-Friesland'},
+    {'gemeente_naam': 'Den Haag', 'gemeente_uri': "'s-Gravenhage"},
+    {'gemeente_naam': 'Den Bosch', 'gemeente_uri': "'s-Hertogenbosch"},
+    {'gemeente_naam': 'De Friese Meren', 'gemeente_uri': 'De Fryske Marren'},
+    {'gemeente_naam': 'Noordoost-Friesland', 'gemeente_uri': 'Noardeast-Fryslân'},
+    {'gemeente_naam': 'Noardeast-Fryslan', 'gemeente_uri': 'Noardeast-Fryslân'},
+    {'gemeente_naam': 'Zuidwest-Friesland', 'gemeente_uri': 'Súdwest-Fryslân'},
+    {'gemeente_naam': 'Sudwest-Fryslan', 'gemeente_uri': 'Súdwest-Fryslân'},
 ]
 alle_gemeenten = [
     {'gemeente_naam': row[2]} for row in kieskringen


### PR DESCRIPTION
Refactored the code to store gemeente alternative names only in the backend, and let the frontend work in a generic way. That way the knowledge only needs to be in one place. Also added additional alternative names. To make sure only the original name shows up in the list, the results are put in a Set (as both names will possible be in the list, e.g. original and alternative name). Names are also sorted to show the in alphabetical order.

Closes #94 Added additional alternative 'gemeentenamen'.
Closes #129 All search results in a single ul element.