### PR TITLE
Adds geolocating using GeoLite database from MaxMind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ previously_published.json
 
 .credentials/*
 client_secret.json
+GeoIP.conf
 
 docker/docker-entrypoint-initdb.d/*.csv
 docker/docker-entrypoint-initdb.d/*.zip

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ around their islands. Before displaying the map we therefore retrieve the countr
 `BQ` (the ISO code for the Caribbean Netherlands) we display the map centered on those islands.
 To geolocate the IP address we use a local copy of the `GeoLite` database from MaxMind.
 
+Note that this works even when the homepage is being cached. Retrieving gelocation takes places using a separate call to the server.
+To make sure that this does not significantly block the user experience when there is a heavy load, the call will time-out after 0.5
+seconds falling back to the default of centering on the Netherlands.
+
 ## Testing
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ To geolocate the IP address we use a local copy of the `GeoLite` database from M
 
 Note that this works even when the homepage is being cached. Retrieving gelocation takes places using a separate call to the server.
 To make sure that this does not significantly block the user experience when there is a heavy load, the call will time-out after 0.5
-seconds falling back to the default of centering on the Netherlands.
+seconds falling back to the default of centering on the Netherlands. The response will also be stored in session cookies, so that
+geolocation takes place only once during a session.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Collecting and presenting stembureaus: [WaarIsMijnStemlokaal.nl](https://waarism
 - Clone or download this project from GitHub:
 - Copy `docker/docker-compose.yml.example` to `docker/docker-compose.yml` and edit it
    - Fill in a password at `<DB_PASSWORD>`
+   - Insert the `GEOIPUPDATE_ACCOUNT_ID` from `Maxmind.com`
+   - Create a new license key on `Maxmind.com` and insert for `GEOIPUPDATE_LICENSE_KEY`
 - Copy `config.py.example` to `config.py` and edit it
    - Create a SECRET_KEY as per the instructions in the file
    - Create a CACHE_PURGE_KEY as per the instructions in the file
@@ -69,6 +71,13 @@ After a rebuild of the assets, the app container must be restarted.
 Development
 - Compile CSS/JS to `static/dist` directory (with map files): `sudo docker exec stm_nodejs_1 yarn build`
 - Automatically compile CSS/JS when a file changes (simply refresh the page in your browser after a change): `sudo docker exec stm_nodejs_1 yarn watch`
+
+
+## Geolocating
+When `WaarIsMijnStemlokaal.nl` is visited from the Caribbean Netherlands (Bonaire, Sint Eustatius and Saba) the map should be centered
+around their islands. Before displaying the map we therefore retrieve the country associated with the visiting IP address. If this is
+`BQ` (the ISO code for the Caribbean Netherlands) we display the map centered on those islands.
+To geolocate the IP address we use a local copy of the `GeoLite` database from MaxMind.
 
 ## Testing
 

--- a/app/assets/package.json
+++ b/app/assets/package.json
@@ -24,6 +24,7 @@
     "cross-env": "^10.1.0",
     "fuse.js": "^7.1.0",
     "jquery": "3.7.1",
+    "js-cookie":"3.0.8",
     "leaflet": "1.9.4",
     "leaflet.awesome-markers": "2.0.5",
     "leaflet.markercluster": "1.5.3",

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -9,6 +9,8 @@ import L from 'leaflet';
 import 'leaflet-geometryutil';
 import 'leaflet.awesome-markers';
 import 'leaflet.markercluster';
+import Cookies from 'js-cookie';
+window.Cookies = Cookies;
 
 // Import local dependencies
 import Router from './util/Router';

--- a/app/assets/scripts/routes/map.js
+++ b/app/assets/scripts/routes/map.js
@@ -374,7 +374,7 @@ export default {
       return $('#form-search input[type="text"]').val();
     }
 
-    var run_stembureaus = function () {
+    var create_map = function () {
       StembureausApp.init();
 
       // Icons for the map markers
@@ -583,13 +583,46 @@ export default {
 
         return output;
       };
+    }
 
+    StembureausApp.display_map_for_location = function () {
+      if (!StembureausApp.homepage) {
+        StembureausApp.display_map();
+        return;
+      }
+
+      var startLongitude = Cookies.get('startLongitude');
+      var startLatitude = Cookies.get('startLatitude');
+      var startZoomfactor = Cookies.get('startZoomfactor');
+      if (startLongitude && startLatitude && startZoomfactor) {
+        StembureausApp.display_map(startLongitude, startLatitude, startZoomfactor);
+        return;
+      }
+
+      $.ajax({
+        url: '/geolocate',
+        complete: function (response, status) {
+          if (status == "success") {
+            var data = response.responseJSON;
+            StembureausApp.display_map(data.start_longitude, data.start_latitude, data.start_zoomfactor);
+            Cookies.set('startLongitude', data.start_longitude);
+            Cookies.set('startLatitude', data.start_latitude);
+            Cookies.set('startZoomfactor', data.start_zoomfactor);
+          } else {
+            StembureausApp.display_map();
+          }
+        },
+        timeout: 500
+      });
+    }
+
+    StembureausApp.display_map = function (startLongitude=5.3, startLatitude=52.2, startZoomfactor=7) {
       var opts = {
         style: 'standaard',
         target: 'map',
         center: {
-          latitude: 52.2,
-          longitude: 5.3
+          latitude: startLatitude,
+          longitude: startLongitude
         },
         overlay: 'false',
         marker: false,
@@ -598,7 +631,7 @@ export default {
       StembureausApp.map = nlmaps.window.nlmaps.createMap(opts);
 
       if (StembureausApp.homepage) {
-        StembureausApp.map.setZoom(7);
+        StembureausApp.map.setZoom(startZoomfactor);
       }
 
       StembureausApp.map.options.zoomSnap = 0.2;
@@ -732,7 +765,7 @@ export default {
     }
 
     if ($('#map').length) {
-      run_stembureaus();
+      create_map();
     }
   },
   // JavaScript to be fired on pages that contain the map, after the init JS

--- a/app/assets/scripts/routes/map.js
+++ b/app/assets/scripts/routes/map.js
@@ -616,6 +616,36 @@ export default {
       });
     }
 
+    StembureausApp.use_brt_layers = function () {
+      if (StembureausApp.map.hasLayer(StembureausApp.brt)) return;
+      if (StembureausApp.error_loading_brt()) return;
+
+      try {
+        StembureausApp.brt_errors = 0;
+        StembureausApp.map.removeLayer(StembureausApp.osm);
+        StembureausApp.map.addLayer(StembureausApp.brt);
+        StembureausApp.chooseLayers.addTo(StembureausApp.map);
+        StembureausApp.map.setMaxZoom(19);
+      } catch (e) { // If a tile cannot be loaded the above will lead to an error, and control is taken over by `tileerror` handler
+        console.error(`Error loading map - ${e.name}: ${e.message}`);
+      }
+    }
+
+    StembureausApp.use_osm_layers = function () {
+      if (StembureausApp.map.hasLayer(StembureausApp.osm)) return;
+
+      StembureausApp.chooseLayers.remove(StembureausApp.map);
+      StembureausApp.map.removeLayer(StembureausApp.brt);
+      StembureausApp.map.removeLayer(StembureausApp.hwh);
+      StembureausApp.map.addLayer(StembureausApp.osm);
+      StembureausApp.map.setMaxZoom(18);
+    }
+
+    // When do we consider loading the brt map failed? For now: when more than 1 (2) tiles fail to load.
+    StembureausApp.error_loading_brt = function () {
+      return StembureausApp.brt_errors > 1;
+    }
+
     StembureausApp.display_map = function (startLongitude=5.3, startLatitude=52.2, startZoomfactor=7) {
       var opts = {
         style: 'standaard',
@@ -640,16 +670,22 @@ export default {
       StembureausApp.map.attributionControl._attributions = {};
 
       // Basisregistratie Topografie (BRT) map used when viewing 'Europees Nederland' on our map
-      var brt = L.tileLayer(
+      StembureausApp.brt = L.tileLayer(
         'https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:3857/{z}/{x}/{y}.png',
         {
           id: 'brt',
           attribution: 'Kaartgegevens &copy; <a href="https://www.kadaster.nl/" target="_blank" rel="noopener">Kadaster</a> | <a href="https://waarismijnstemlokaal.nl/" target="_blank" rel="noopener">Waar is mijn stemlokaal</a>'
         }
-      );
+      ).on('tileerror', function () {
+          StembureausApp.brt_errors += 1;
+          if (StembureausApp.error_loading_brt()) {
+            StembureausApp.brt._abortLoading();
+            StembureausApp.use_osm_layers();
+          }
+      });
 
       // Alternative for BRT, luchtfoto
-      var hwh = L.tileLayer(
+      StembureausApp.hwh = L.tileLayer(
         'https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0/Actueel_ortho25/EPSG:3857/{z}/{x}/{y}.png',
         {
           id: 'hwh',
@@ -658,13 +694,13 @@ export default {
       );
 
       var baseLayers = {
-        "Kaart": brt,
-        "Luchtfoto": hwh
+        "Kaart": StembureausApp.brt,
+        "Luchtfoto": StembureausApp.hwh
       };
 
       // OpenStreetMap map used when viewing all other places outside 'Europees Nederland' on our map,
       // because BRT doesn't have that data
-      var osm = L.tileLayer(
+      StembureausApp.osm = L.tileLayer(
         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         {
           id: 'osm',
@@ -672,18 +708,15 @@ export default {
         }
       );
 
-      var chooseLayers = L.control.layers(baseLayers, {}, {position: 'bottomright', collapsed: false})
+      StembureausApp.chooseLayers = L.control.layers(baseLayers, {}, {position: 'bottomright', collapsed: false})
 
       // Use BRT in 'Europees Nederland' and OSM for the rest
       var zoom = StembureausApp.map.getZoom();
       var center = StembureausApp.map.getCenter();
       if (zoom >= 7 && center.lat > 50 && center.lat < 54 && center.lng > 3 && center.lng < 8) {
-        StembureausApp.map.addLayer(brt);
-        chooseLayers.addTo(StembureausApp.map);
-        StembureausApp.map.setMaxZoom(19);
+        StembureausApp.use_brt_layers();
       } else {
-        StembureausApp.map.addLayer(osm);
-        StembureausApp.map.setMaxZoom(18);
+        StembureausApp.use_osm_layers();
       }
 
       // Show BRT only when zoomed in on European Netherlands, use OSM for
@@ -692,16 +725,9 @@ export default {
         var zoom = StembureausApp.map.getZoom();
         var center = StembureausApp.map.getCenter();
         if (zoom >= 7 && center.lat > 50 && center.lat < 54 && center.lng > 3 && center.lng < 8) {
-          StembureausApp.map.removeLayer(osm);
-          StembureausApp.map.addLayer(brt);
-          chooseLayers.addTo(StembureausApp.map);
-          StembureausApp.map.setMaxZoom(19);
+          StembureausApp.use_brt_layers();
         } else {
-          chooseLayers.remove(StembureausApp.map);
-          StembureausApp.map.removeLayer(brt);
-          StembureausApp.map.removeLayer(hwh);
-          StembureausApp.map.addLayer(osm);
-          StembureausApp.map.setMaxZoom(18);
+          StembureausApp.use_osm_layers();
         }
       });
 

--- a/app/assets/yarn.lock
+++ b/app/assets/yarn.lock
@@ -583,6 +583,11 @@ jquery@3.7.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
 
+js-cookie@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.8.tgz#444e6f4b27a5d844594fef61c9d6bca5f0787688"
+  integrity sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==
+
 leaflet-geometryutil@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/leaflet-geometryutil/-/leaflet-geometryutil-0.10.3.tgz#dda78546abc58723a46b47fd6ffb081f5b63cec4"

--- a/app/geo_locator.py
+++ b/app/geo_locator.py
@@ -1,0 +1,34 @@
+import geoip2.database
+
+class GeoLocator:
+
+  def __init__(self, config, logger):
+    self.mapping = config['COUNTRY_CODE_TO_MAP']
+    self.logger = logger
+    try:
+      self.country_reader = geoip2.database.Reader('/usr/share/GeoIP/GeoLite2-Country.mmdb')
+      self.logger.info("Successfully initialized GeoLocator reader")
+    except Exception as e:
+      self.logger.error(f"Error initializing GeoLocator reader: {str(e)}")
+      self.country_reader = None
+
+
+  def get_longitude_and_latitude(self, ip_address):
+    country_code = self.get_country_code(ip_address)
+
+    if country_code and country_code in self.mapping:
+      return self.mapping[country_code]
+    else:
+      return self.mapping['NL']
+
+
+  def get_country_code(self, ip_address):
+    if not self.country_reader:
+      return
+
+    try:
+      response = self.country_reader.country(ip_address)
+      return response.country.iso_code
+    except Exception as e:
+      self.logger.error(f"Error getting geolocation for ip address {ip_address}, error: {str(e)}")
+      return 'error'

--- a/app/geo_locator.py
+++ b/app/geo_locator.py
@@ -1,22 +1,33 @@
 import geoip2.database
 
 class GeoLocator:
+  CARIBBEAN_NETHERLANDS_ISO_CODE = 'BQ'
+  BONAIRE_CUSTOM_CODE = 'BQ-Bonaire'
+  SINT_EUSTATIUS_CUSTOM_CODE = 'BQ-Sint-Eustatius'
+  SABA_CUSTOM_CODE = 'BQ-Saba'
 
   def __init__(self, config, logger):
     self.mapping = config['COUNTRY_CODE_TO_MAP']
     self.logger = logger
     try:
       self.country_reader = geoip2.database.Reader('/usr/share/GeoIP/GeoLite2-Country.mmdb')
+      self.city_reader = geoip2.database.Reader('/usr/share/GeoIP/GeoLite2-City.mmdb')
       self.logger.info("Successfully initialized GeoLocator reader")
     except Exception as e:
       self.logger.error(f"Error initializing GeoLocator reader: {str(e)}")
       self.country_reader = None
+      self.city_reader = None
 
 
   def get_longitude_and_latitude(self, ip_address):
     country_code = self.get_country_code(ip_address)
+    if not country_code:
+      return self.mapping['NL']
 
-    if country_code and country_code in self.mapping:
+    if country_code == self.CARIBBEAN_NETHERLANDS_ISO_CODE:
+      country_code = self.get_island_code(ip_address)
+
+    if country_code in self.mapping:
       return self.mapping[country_code]
     else:
       return self.mapping['NL']
@@ -32,3 +43,26 @@ class GeoLocator:
     except Exception as e:
       self.logger.error(f"Error getting geolocation for ip address {ip_address}, error: {str(e)}")
       return 'error'
+
+  # Try to determine which island. If that fails, return CARIBBEAN_NETHERLANDS_ISO_CODE to center map so that
+  # all three islands are visible
+  def get_island_code(self, ip_address):
+    if not self.city_reader:
+      return self.CARIBBEAN_NETHERLANDS_ISO_CODE
+
+    try:
+      response = self.city_reader.city(ip_address)
+      longitude = response.location.longitude
+      latitude = response.location.latitude
+
+      if longitude > -68.49 and longitude < -68.10 and latitude > 11.94 and latitude < 12.38:
+        return self.BONAIRE_CUSTOM_CODE
+      elif longitude > -63.03 and longitude < -62.90 and latitude > 17.43 and latitude < 17.55:
+        return self.SINT_EUSTATIUS_CUSTOM_CODE
+      elif longitude > -63.28 and longitude < -63.18 and latitude > 17.58 and latitude < 17.67:
+        return self.SABA_CUSTOM_CODE
+      else:
+        return self.CARIBBEAN_NETHERLANDS_ISO_CODE
+    except Exception as e:
+      self.logger.error(f"Error getting island geolocation for ip address {ip_address}, error: {str(e)}")
+      return self.CARIBBEAN_NETHERLANDS_ISO_CODE

--- a/app/routes.py
+++ b/app/routes.py
@@ -428,7 +428,6 @@ def create_routes(app):
     @app.route("/geolocate")
     def geolocate():
         ip_address = request.remote_addr
-        # ip_address = '143.0.32.100' # RVD
         start_longitude, start_latitude, start_zoomfactor = geo_locator.get_longitude_and_latitude(ip_address)
         location = {
             'start_longitude': start_longitude,

--- a/app/routes.py
+++ b/app/routes.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from app.cache_purger import CachePurger
 from app.form_utils import create_record, kieskringen
+from app.geo_locator import GeoLocator
 from app.procura import ProcuraManager
 from app.stembureaumanager import StembureauManager
 from app.tsa import TSAManager
@@ -173,6 +174,7 @@ toegankelijkheid_descriptions = {
     'prokkelduo': 'Is er een <a href="https://www.prokkel.nl/inclusieve-stembureaus/" target="_blank">prokkelduo</a> aanwezig op dit stembureau? Een prokkelduo bestaat uit twee vrijwilligers, één met een (licht) verstandelijke beperking en één zonder, die samen verschillende taken op het stembureau uitvoeren.'
 }
 
+geo_locator = GeoLocator(current_app.config, current_app.logger)
 
 # Do not show the informational messages in base.html for these routes
 skip_informational_messages_for = [
@@ -422,6 +424,18 @@ def create_routes(app):
             signup_form=signup_form
         )
 
+
+    @app.route("/geolocate")
+    def geolocate():
+        ip_address = request.remote_addr
+        # ip_address = '143.0.32.100' # RVD
+        start_longitude, start_latitude, start_zoomfactor = geo_locator.get_longitude_and_latitude(ip_address)
+        location = {
+            'start_longitude': start_longitude,
+            'start_latitude' : start_latitude,
+            'start_zoomfactor': start_zoomfactor
+        }
+        return jsonify(location)
 
     @app.route("/s/<gemeente>/<primary_key>")
     def show_stembureau(gemeente, primary_key):

--- a/app/templates/map_scripts.html
+++ b/app/templates/map_scripts.html
@@ -4,4 +4,10 @@
   var StembureausApp = window.StembureausApp || {stembureaus: [], links_external: false};
   StembureausApp.election_date = "{{ config['ELECTION_DATE'] }}";
   StembureausApp.stembureaus = {{ records |tojson |safe }};
+
+  $(document).ready(function() {
+    if ($('#map').length) {
+      StembureausApp.display_map_for_location();
+    }
+  });
 </script>

--- a/app/templates/over-deze-website.html
+++ b/app/templates/over-deze-website.html
@@ -78,6 +78,11 @@
         <li><a href="/static/dist/images/WIMS_Banners.zip">.zip</a> van alle vier de banners</li>
     </ul>
 
+    <h2>Geolocalisatie</h2>
+    <p>Om het vinden van een stembureau zo makkelijk mogelijk te maken wordt voor bezoekers vanaf Caribbisch Nederland de
+      kaart gecentreerd rond de eilanden getoond. Voor het bepalen vanaf welk gebied de kaart opgevraagd wordt gebruiken
+    we een lokale versie van de GeoLite database van <a href="https://www.maxmind.com" target="_blank">MaxMind</a>.</p>
+
     <h2>Contact</h2>
     <p>Heeft u vragen over het platform? Stuur dan een e-mail naar <a href="mailto:stemlokaal@openstate.eu">stemlokaal@openstate.eu</a>. Voor algemene vragen over de verkiezingen kunt u terecht bij uw gemeente of op <a href="https://elkestemtelt.nl/" target="_blank" rel="noopener">ElkeStemTelt.nl</a> van de Rijksoverheid.</p>
   </div>

--- a/config.py.example
+++ b/config.py.example
@@ -130,3 +130,9 @@ class Config(object):
     # Monitoring settings
     MAX_GEMEENTEN_PER_USER = 5
     MAX_GEMEENTEN_PER_USER_EXCEPTIONS = []
+
+    # Entries are [longitude, latitude, zoomfactor]
+    COUNTRY_CODE_TO_MAP = {
+        'NL': [5.3, 52.2, 7],
+        'BQ': [-65.6, 15.1, 6] # Bonaire, Sint Eustatius, Saba
+    }

--- a/config.py.example
+++ b/config.py.example
@@ -134,5 +134,8 @@ class Config(object):
     # Entries are [longitude, latitude, zoomfactor]
     COUNTRY_CODE_TO_MAP = {
         'NL': [5.3, 52.2, 7],
-        'BQ': [-65.6, 15.1, 6] # Bonaire, Sint Eustatius, Saba
+        'BQ': [-65.6, 15.1, 6], # Bonaire, Sint Eustatius, Saba
+        'BQ-Bonaire': [-68.29, 12.18, 11], # Custom code for Bonaire
+        'BQ-Sint-Eustatius': [-62.97, 17.50, 13], # Custom code for Sint-Eustatius
+        'BQ-Saba': [-63.24, 17.633, 14] # Custom code for Saba
     }

--- a/docker/docker-compose.yml.example
+++ b/docker/docker-compose.yml.example
@@ -63,10 +63,26 @@ services:
     # Use this to keep the container running
     tty: true
     restart: always
+  geoipupdate:
+    container_name: geoipupdate
+    image: ghcr.io/maxmind/geoipupdate
+    restart: unless-stopped
+    environment:
+      - GEOIPUPDATE_ACCOUNT_ID=XXXXXX
+      - GEOIPUPDATE_LICENSE_KEY=XXXXXXXXXXXXXXXX
+      - 'GEOIPUPDATE_EDITION_IDS=GeoLite2-City GeoLite2-Country'
+      - GEOIPUPDATE_FREQUENCY=72
+    networks:
+      - geoipupdate
+    volumes:
+      - 'geoipupdate_data:/usr/share/GeoIP'
 networks:
   stm:
+  geoipupdate:
   nginx-load-balancer:
     external:
       name: docker_nginx-load-balancer
 volumes:
   stm-mysql-volume:
+  geoipupdate_data:
+    driver: local

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -20,6 +20,7 @@ qrcode[pil]==8.2
 pyproj==3.7.2
 nose2==0.15.1
 python-dateutil==2.9.0.post0
+geoip2==5.3.0
 
 # Dependencies installed by the packages above
 cryptography==48.0.1 # for PyMySQL


### PR DESCRIPTION
Geolocation takes place using local version of GeoLite database from MaxMind. It is done in a separate JS call so that it will still work when caching is enabled.
A timeout of 0.5s is used to ensure that geolocation does not significantly block the user experience when the server is under heavy load.